### PR TITLE
loosening dependencies to allow upgrades of rails and mongoid

### DIFF
--- a/lib/mongo_coffee/version.rb
+++ b/lib/mongo_coffee/version.rb
@@ -1,3 +1,3 @@
 module MongoCoffee
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/mongo_coffee.gemspec
+++ b/mongo_coffee.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split("\n")
 
-  s.add_dependency "rails", "~> 3.2.14"
+  s.add_dependency "rails", ">= 3.2.14"
   s.add_dependency "coffee-script", "~> 2.2.0"
-  s.add_dependency "mongoid", "~> 3.1.0"
+  s.add_dependency "mongoid", ">= 3.1.0"
 end


### PR DESCRIPTION
Hey! 

To allow upgrades to rails 4 and beyond and mongoid new versions, I have been forced to change dependencies restrictions.
